### PR TITLE
fix(criteria): CPU/GPU device mismatch in fairness loss

### DIFF
--- a/src/weavenet/criteria.py
+++ b/src/weavenet/criteria.py
@@ -104,7 +104,7 @@ class CriteriaStableMatching():
             
             l = loss_fairness(m, sab, sba_t) 
             
-            loss += fairness_weight * l * ((loss.detach()<=0).max(torch.tensor([not gate_fairness_loss])).to(l.dtype))
+            loss += fairness_weight * l * ((loss.detach()<=0).max(torch.tensor([not gate_fairness_loss], device=l.device)).to(l.dtype))
             # equivalent to ...
             #  if not self.gate_fairness_loss:
             #    loss = fairness_weight * l


### PR DESCRIPTION
## Summary

`CriteriaStableMatching.generate_criterion` constructs an inline `torch.tensor([not gate_fairness_loss])` without a `device=` arg, so on GPU training with `fairness != None` it raises:

> RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!

The tensor's only role is as a constant operand to `.max(...)` against the GPU tensor `(loss.detach()<=0)`, so threading `device=l.device` through the constructor keeps the value identical while placing it on the correct device.

```diff
-            loss += fairness_weight * l * ((loss.detach()<=0).max(torch.tensor([not gate_fairness_loss])).to(l.dtype))
+            loss += fairness_weight * l * ((loss.detach()<=0).max(torch.tensor([not gate_fairness_loss], device=l.device)).to(l.dtype))
```

## Repro

```python
import torch
from weavenet.criteria import CriteriaStableMatching
crit = CriteriaStableMatching(fairness='sexequality', fairness_weight=0.01).generate_criterion()
m = torch.rand(2, 30, 30, 1, device='cuda')
sab = torch.rand(2, 30, 30, device='cuda')
sba_t = torch.rand(2, 30, 30, device='cuda')
crit(m, sab, sba_t)  # raises RuntimeError pre-fix
```

## Test plan

- [x] confirm GPU training with `fairness='sexequality'` no longer raises
- [x] CPU training is unaffected (no behavior change there)