### PR TITLE
fix(model): residual on side-b stream was silently dropped (xba_t typo)

### DIFF
--- a/src/weavenet/model.py
+++ b/src/weavenet/model.py
@@ -331,7 +331,7 @@ class MatchingNet(nn.Module):
                     xba_t_keep = xba_t
                 if calc_res:
                     xab_keep, xab = xab, xab + xab_keep
-                    xba_t_keep, xba = xba_t, xba_t + xba_t_keep
+                    xba_t_keep, xba_t = xba_t, xba_t + xba_t_keep
             if l<self.L-1:
                 xab, xba_t = self.interactor(xab, xba_t)            
         


### PR DESCRIPTION
## Summary

`MatchingNet.forward` does a symmetric tuple-unpack to apply the residual addition to both streams, but the second line assigns to `xba` instead of `xba_t`:

```python
if calc_res:
    xab_keep, xab = xab, xab + xab_keep
    xba_t_keep, xba = xba_t, xba_t + xba_t_keep   # ← typo: xba (should be xba_t)
```

After this block the loop continues with the original (non-residualized) `xba_t` while the residual-added value lands in `xba`, an otherwise-unused local. Net effect: **residual connections are applied only to side-a; side-b silently has no residual structure.**

Any deep WeaveNet trained with `calc_residual` becomes asymmetric — `xab` benefits from shortcut paths while `xba_t` does not — so the two streams have effectively different depth-equivalent capacity.

```diff
                 if calc_res:
                     xab_keep, xab = xab, xab + xab_keep
-                    xba_t_keep, xba = xba_t, xba_t + xba_t_keep
+                    xba_t_keep, xba_t = xba_t, xba_t + xba_t_keep
```

## Impact observed

Training a paper-spec WN-60 (60 layers, residual every two layers) on GG30x30 with `fairness='sexequality'` and weight 0.01 collapsed at `is_success=0%` and `num_blocking_pair > 1000` until this fix landed. With the fix applied (and #3 to enable the fairness path at all), the same hyperparameters reach `is_success=6.1%` / `num_blocking_pair=11.2` in 100 epochs and continue improving.

## Test plan

- [x] check that the residual values now land in `xba_t` (a one-line `print` or assert is enough)
- [x] re-run any test that explicitly exercises `calc_residual` with two streams