### PR TITLE
feat(layers): add MeanAggregator (paper-recipe friendly stream aggregator)

### DIFF
--- a/src/weavenet/layers.py
+++ b/src/weavenet/layers.py
@@ -549,7 +549,46 @@ class DualSoftmaxFuzzyLogicAnd(DualSoftmax):
         """
         zab, zba_t = self._apply_softmax(xab, xba_t)
         return zab.min(zba_t), zab, zba_t
-        
+
+class MeanAggregator(StreamAggregatorTHRU):
+    r"""
+
+    Aggregates two stream outputs by their arithmetic mean, returning raw
+    (un-normalized) values.
+
+    .. math::
+        \text{MeanAggregator}(x^{ab}_{ij}, x^{ba}_{ij}) = \frac{x^{ab}_{ij} + x^{ba}_{ij}}{2}
+
+    Use this when downstream code (typically the loss/criterion) is responsible
+    for any probability normalization, rather than baking softmax into the
+    network output. This is the aggregation used by the original WeaveNet
+    paper (arXiv:2310.12515): ``MatcherWeaveNet.forward`` averages the two
+    stream outputs as raw logits, then ``CriteriaStableMatching`` applies
+    ``softmax(., dim=-1)`` and ``softmax(., dim=-2)`` separately inside the
+    loss. Compose with such a criterion if you want to reproduce that recipe.
+
+    For contrast, :class:`DualSoftmaxSqrt` (the package default) folds the
+    softmax normalization into the network output itself.
+    """
+    def forward(self,
+                xab:torch.Tensor,
+                xba_t:Optional[torch.Tensor]=None)->Tuple[torch.Tensor,torch.Tensor,torch.Tensor]:
+        r"""
+
+        **Shape and Args**: same as :class:`DualSoftmax`
+
+        Args:
+           xab: 1st batched matrices.
+
+           xba_t: 2nd batched matrices. If None, **xab** is used as **xba_t**.
+
+        Returns:
+           a triplet of **(xab + xba_t) / 2**, **xab**, **xba_t**.
+
+        """
+        xba_t = self.set_xba_t(xab, xba_t)
+        return (xab + xba_t) / 2, xab, xba_t
+
 class CrossConcatVertexFeatures(Interactor):
     r""" CrossConcat vertex features for side `a` and `b`, which are typically provided from a feature extractor.
 


### PR DESCRIPTION
## Summary

Adds `MeanAggregator` to `weavenet.layers`, a stream aggregator that returns the arithmetic mean of two stream outputs as raw values:

```math
\text{MeanAggregator}(x^{ab}_{ij}, x^{ba}_{ij}) = \frac{x^{ab}_{ij} + x^{ba}_{ij}}{2}
```

No softmax is applied at the network output; downstream code (typically the criterion) handles probability normalization.

## Motivation

The original WeaveNet paper (arXiv:2310.12515) aggregates the two stream outputs by **raw mean** inside `MatcherWeaveNet.forward`, then `CriteriaStableMatching` applies `softmax(., dim=-1)` and `softmax(., dim=-2)` separately inside the loss. The current package default `DualSoftmaxSqrt` instead folds that normalization into the network output. Both designs make sense, but reproducing the paper's training recipe requires the raw-mean option.

The new class sits next to `DualSoftmax`, `DualSoftmaxSqrt`, and `DualSoftmaxFuzzyLogicAnd`, so users now choose explicitly between four aggregator variants:

| class | output |
|---|---|
| `DualSoftmaxSqrt` (default) | `sqrt(softmax_row * softmax_col)` |
| `DualSoftmax` | `softmax_row * softmax_col` |
| `DualSoftmaxFuzzyLogicAnd` | `min(softmax_row, softmax_col)` |
| `MeanAggregator` (new) | `(xab + xba_t) / 2` (raw) |

## Implementation

Inherits from `StreamAggregatorTHRU` and matches the existing `(m, xab, xba_t)` triplet return signature.

## Test plan

- [x] manual smoke test (see commit): mean equals `(1 + 3) / 2 = 2`, `xba_t=None` falls through to `xab`
- [ ] suggested: add a unit test mirroring the smoke test above